### PR TITLE
replace deprecated scipy.ndimage with imageio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 ._*
 /dist
 MANIFEST
+
+/build/

--- a/pdfdocument/document.py
+++ b/pdfdocument/document.py
@@ -18,7 +18,7 @@ from reportlab.platypus.flowables import HRFlowable
 import copy
 import sys
 import unicodedata
-from scipy.ndimage import imread
+from imageio import imread
 
 PY2 = (sys.version_info[0] < 3)
 


### PR DESCRIPTION
scipy.ndimage.imread is deprecated.

Replace it with imageio.imread instead.

Add /build/ to gitignore for convenience in installing the package.